### PR TITLE
Try to get stock name from suggestions when it comes back "N/A"

### DIFF
--- a/src/nitezh/ministock/StockSuggestions.java
+++ b/src/nitezh/ministock/StockSuggestions.java
@@ -42,7 +42,7 @@ import nitezh.ministock.utils.StorageCache;
 import nitezh.ministock.utils.UrlDataTools;
 
 
-class StockSuggestions {
+public class StockSuggestions {
 
     private static final String BASE_URL = "http://d.yimg.com/autoc.finance.yahoo.com/autoc?callback=YAHOO.Finance.SymbolSuggest.ssCallback&query=";
     private static final Pattern PATTERN_RESPONSE = Pattern.compile("YAHOO\\.Finance\\.SymbolSuggest\\.ssCallback\\((\\{.*?\\})\\)");

--- a/src/nitezh/ministock/domain/StockQuote.java
+++ b/src/nitezh/ministock/domain/StockQuote.java
@@ -148,4 +148,8 @@ public class StockQuote {
     public String getName() {
         return name;
     }
+
+    public void setName(String name) {
+        this.name = name;
+    }
 }

--- a/src/nitezh/ministock/domain/StockQuoteRepository.java
+++ b/src/nitezh/ministock/domain/StockQuoteRepository.java
@@ -30,8 +30,10 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import nitezh.ministock.StockSuggestions;
 import nitezh.ministock.utils.Cache;
 import nitezh.ministock.Storage;
 import nitezh.ministock.dataaccess.FxChangeRepository;
@@ -86,9 +88,31 @@ public class StockQuoteRepository {
                     .replace(".DJI", "^DJI")
                     .replace(".IXIC", "^IXIC");
             quote.setSymbol(newSymbol);
+            if ("N/A".equalsIgnoreCase(quote.getName())) {
+                String nameFromStockSuggestions = getNameFromStockSuggestions(newSymbol);
+                if (!nameFromStockSuggestions.isEmpty()){
+                    quote.setName(nameFromStockSuggestions);
+                }
+            }
             newQuotes.put(newSymbol, quote);
         }
         return newQuotes;
+    }
+
+    private String getNameFromStockSuggestions(String symbol) {
+        String name = "";
+
+        if (symbol != null && !symbol.isEmpty()) {
+            List<Map<String, String>> suggestions = StockSuggestions.getSuggestions(symbol);
+            for (Map<String, String> suggestion : suggestions) {
+                if (symbol.equals(suggestion.get("symbol"))) {
+                    name = suggestion.get("name");
+                    break;
+                }
+            }
+        }
+
+        return name;
     }
 
     private List<String> convertRequestSymbols(List<String> symbols) {


### PR DESCRIPTION
I've had a couple of stocks show up on the widget with "N/A" as the name (ITEK is an example), but I noticed that it showed up in suggestions and the preferences page correctly.  I made this update to attempt to get the stock name from suggestions if it comes back "N/A" from the quotes api.